### PR TITLE
Added a claim "isAuthenticated" as "true"

### DIFF
--- a/todo-react-firebase/functions/index.js
+++ b/todo-react-firebase/functions/index.js
@@ -6,7 +6,8 @@ exports.addUserClaim = functions.https.onCall((data, context) => {
 	return admin.auth().getUserByEmail(data.email).then(user=>{
 		return admin.auth().setCustomUserClaims(user.uid, {
 			"https://dgraph.io/jwt/claims":{
-				"USER": data.email
+				"USER": data.email,
+				"isAuthenticated" : "true"
 			}
 		});
 	}).then(() => {


### PR DESCRIPTION
This change was made to align with an @auth example mentioned in the docs (see below).

Auth doc: https://dgraph.io/docs/graphql/authorization/directive/
Snippet from documentation:

Ensuring that requests are from an authenticated JWT, and no further restrictions, can be done by arranging the JWT to contain a value like "isAuthenticated": "true". For example,

type User @auth(
    query: { rule:  "{$isAuthenticated: { eq: \"true\" } }" },
) {
    username: String! @id
    todos: [Todo]
}

specifies that only authenticated users can query other users.